### PR TITLE
Allow Angular 1.3 as dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": "~1.2.x"
+    "angular": "^1.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.x"

--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,6 @@
     "angular": "^1.2"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.x"
+    "angular-mocks": "^1.2"
   }
 }


### PR DESCRIPTION
I'm running Angular 1.3 with this library. Haven't notice any problems so far.